### PR TITLE
Minor documentation edits

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -177,9 +177,11 @@ convert HTML provided via stdin and save the output to output.txt::
 
 HTML to annotated text conversion
 ---------------------------------
-convert and annotate HTML from a Web page using the provided annotation rules::
+convert and annotate HTML from a Web page using the provided annotation rules. 
 
-  $ inscript.py https://www.fhgr.ch -r ./examples/annotation-profile.json
+Download the example `annotation-profile.json <https://github.com/weblyzard/inscriptis/blob/master/examples/annotation-profile.json>`_ and save it to your working directory::
+
+  $ inscript.py https://www.fhgr.ch -r annotation-profile.json
 
 The annotation rules are specified in `annotation-profile.json`:
 

--- a/README.rst
+++ b/README.rst
@@ -150,7 +150,7 @@ The inscript.py command line client supports the following parameters::
     -l, --display-link-targets
                           Display link targets (default:false).
     -a, --display-anchor-urls
-                          Deduplicate image captions (default:false).
+                          Display anchor urls (default:false).
     -r ANNOTATION_RULES, --annotation-rules ANNOTATION_RULES
                           Path to an optional JSON file containing rules for annotating the retrieved text.
     -p POSTPROCESSOR, --postprocessor POSTPROCESSOR
@@ -172,7 +172,7 @@ convert the file to text and save the output to output.txt::
    
 convert HTML provided via stdin and save the output to output.txt::
 
-  $ echo '<body><p>Make it so!</p>></body>' | inscript.py -o output.txt 
+  $ echo '<body><p>Make it so!</p></body>' | inscript.py -o output.txt 
 
 
 HTML to annotated text conversion

--- a/scripts/inscript.py
+++ b/scripts/inscript.py
@@ -55,7 +55,7 @@ def get_parser():
                         help='Display link targets (default:false).')
     parser.add_argument('-a', '--display-anchor-urls',
                         action='store_true', default=False,
-                        help='Deduplicate image captions (default:false).')
+                        help='Display anchor urls (default:false).')
     parser.add_argument('-r', '--annotation-rules', default=None,
                         help='Path to an optional JSON file containing rules '
                              'for annotating the retrieved text.')


### PR DESCRIPTION
As I was working through the documentation I made corrections for a few minor problems:

- duplicate help text for one of the command line script arguments in both readme and script
- extra `>` in the sample html string in the stdin example
- annotation rule example assumes that the user has checked out the repository and not installed via pip/easy_install; I suggested a way to revise it to make it easier to follow