### PR TITLE
wip: use waitress to serve http

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-FROM python:3
+FROM python:3.9-slim-bullseye
 LABEL maintainer="albert.weichselbraun@fhgr.ch"
+
+RUN apt update && apt install python3-waitress -y
 
 RUN mkdir /inscriptis
 COPY ./ /inscriptis/
@@ -9,6 +11,5 @@ RUN pip install --no-cache-dir -r requirements.txt && \
     pip install --no-cache-dir Flask && \
     python setup.py install
 
-ENV FLASK_APP="inscriptis.service.web"
-CMD ["python3", "-m", "flask", "run"]
+CMD ["waitress-serve", "src.inscriptis.service.web:app"]
 EXPOSE 5000

--- a/src/inscriptis/service/web.py
+++ b/src/inscriptis/service/web.py
@@ -3,6 +3,7 @@
 """Inscriptis Web Service."""
 
 from flask import request, Response, Flask
+from waitress import serve
 
 from inscriptis import get_text
 from inscriptis.metadata import __version__
@@ -41,4 +42,4 @@ def get_version_call():
 
 if __name__ == '__main__':
     print('Starting Web service based on Inscriptis', __version__)
-    app.run(threaded=True, host='127.0.0.1', port=5000)
+    serve(app, host='0.0.0.0', port=5000)


### PR DESCRIPTION
this is how I got to accept inscriptis as a service, however waitress throws the following error: 

```bash
phil@tokyo:~/inscriptis$ docker run  ghcr.io/philippkuntschik/inscriptis
Error: Bad module 'src.inscriptis.service.web'

... [all waitress options] ...

There was an exception (ModuleNotFoundError) importing your module.

It had these arguments: 
1. No module named 'lxml'
```

Maybe you can debug this faster from here since a) I have no idea why web.py throws errors about lxml and b) you mentioned that there was a lxml bug fixed with version 2.3.0.

from a benchmarking perspective, using the bullseye-slim packages reduces container-size by 80%

```
phil@tokyo:~/inscriptis$ docker images
REPOSITORY                                           TAG      IMAGE ID       CREATED             SIZE
ghcr.io/philippkuntschik/inscriptis                  latest   631793c3837e   16 minutes ago      204MB
ghcr.io/weblyzard/inscriptis                         latest   deda58089f88   3 hours ago         956MB
ghcr.io/weblyzard/inscriptis/inscriptis-web-service  2.3.0    2d95c7bf86d8   2 days ago          1.13GB
```

a representative build process is here: https://github.com/PhilippKuntschik/inscriptis/runs/7673920038?check_suite_focus=true
