### PR TITLE
chg: considerably improved build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,27 @@
-FROM python:3
-LABEL maintainer="albert.weichselbraun@fhgr.ch"
-
-RUN mkdir /inscriptis
-COPY ./ /inscriptis/
+#
+# Stage 1 - Install build dependencies
+#
+FROM python:3.9-slim-bullseye AS builder
 
 WORKDIR /inscriptis
-RUN pip install --no-cache-dir -r requirements.txt && \
-    pip install --no-cache-dir Flask && \
-    python setup.py install
+COPY requirements.txt .
+RUN python -m venv .venv && .venv/bin/python -m pip install --upgrade pip
+RUN .venv/bin/pip install --no-cache-dir -r requirements.txt && \
+    .venv/bin/pip install --no-cache-dir Flask waitress && \
+    find /inscriptis/.venv \( -type d -a -name test -o -name tests \) -o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) -exec rm -rf '{}' \+
 
-ENV FLASK_APP="inscriptis.service.web"
-CMD ["python3", "-m", "flask", "run"]
+#
+# Stage 2 - Copy only necessary files to the runner stage
+#
+FROM python:3.9-slim-bullseye 
+LABEL maintainer="albert.weichselbraun@fhgr.ch"
+
+# Note: only copy the src directory, to prevent bloating the image with 
+#       irrelevant files from the project directory.
+WORKDIR /inscriptis/src
+COPY --from=builder /inscriptis /inscriptis
+COPY ./src /inscriptis/src
+
+ENV PATH="/inscriptis/.venv/bin:$PATH"
+CMD ["waitress-serve", "inscriptis.service.web:app"]
 EXPOSE 5000


### PR DESCRIPTION
- based on the work done by @PhilippKuntschik 
- use python:3.7-slim images and a two-stage build process.
- reduce image size from over 1 GB to approximately 160 MB :)