### PR TITLE
automatically publish helm releases page.

### DIFF
--- a/.github/workflows/create-container.yml
+++ b/.github/workflows/create-container.yml
@@ -33,7 +33,7 @@ jobs:
         tags: |
           ghcr.io/weblyzard/inscriptis:v${{ steps.version.outputs.APP_VERSION }}
           ghcr.io/weblyzard/inscriptis:latest
-          
+
     - name: publish helm
       uses: helm/chart-releaser-action@v1.4.0
       with:

--- a/.github/workflows/create-container.yml
+++ b/.github/workflows/create-container.yml
@@ -38,3 +38,5 @@ jobs:
       uses: helm/chart-releaser-action@v1.4.0
       with:
         charts_dir: helm
+      env:
+        CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/create-container.yml
+++ b/.github/workflows/create-container.yml
@@ -33,3 +33,8 @@ jobs:
         tags: |
           ghcr.io/weblyzard/inscriptis:v${{ steps.version.outputs.APP_VERSION }}
           ghcr.io/weblyzard/inscriptis:latest
+          
+    - name: publish helm
+      uses: helm/chart-releaser-action@v1.4.0
+      with:
+        charts_dir: helm


### PR DESCRIPTION
see https://github.com/helm/chart-releaser#chart-releaser

## Pre-requisites

- [X] A GitHub repo containing a directory with your Helm charts (default is a folder named /charts, if you want to maintain your charts in a different directory, you must include a charts_dir input in the workflow).
- [X] A GitHub branch called gh-pages to store the published charts. See charts_repo_url for alternatives.
- [x] In your repo, go to Settings/Pages. Change the Source Branch to gh-pages.
- [X] Create a workflow .yml file in your .github/workflows directory. An [example workflow](https://github.com/helm/chart-releaser-action#example-workflow) is available below. For more information, reference the GitHub Help Documentation for [Creating a workflow file](https://help.github.com/en/articles/configuring-a-workflow#creating-a-workflow-file)