### PR TITLE
change used port back to 5000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,5 @@ COPY --from=builder /inscriptis /inscriptis
 COPY ./src /inscriptis/src
 
 ENV PATH="/inscriptis/.venv/bin:$PATH"
-CMD ["waitress-serve", "inscriptis.service.web:app"]
+CMD ["waitress-serve", "inscriptis.service.web:app", "--port=5000", "--host=0.0.0.0"]
 EXPOSE 5000


### PR DESCRIPTION
waitress deploys on 8080, but inscriptis-users may be used to 5000

```
root@inscriptis-fc9c4954d-7fp89:/inscriptis/src# ss -ltnp
State                  Recv-Q                 Send-Q                                 Local Address:Port                                  Peer Address:Port                 Process                                                
LISTEN                 0                      128                                        127.0.0.1:4140                                       0.0.0.0:*                                                                           
LISTEN                 0                      128                                          0.0.0.0:4143                                       0.0.0.0:*                                                                           
LISTEN                 0                      1024                                         0.0.0.0:8080                                       0.0.0.0:*                     users:(("waitress-serve",pid=1,fd=6))                 
LISTEN                 0                      128                                          0.0.0.0:4190                                       0.0.0.0:*                                                                           
LISTEN                 0                      128                                          0.0.0.0:4191                                       0.0.0.0:*                                 
```