### PR TITLE
Update dependencies in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ web-service = ["fastapi", "uvicorn"]
 
 [tool.poetry.dependencies]
 python = "^3.9 || ^3.10 || ^3.11 || ^3.12 || ^3.13"
-requests = "2.32.2"
+requests = ">=2.32.2"
 lxml = ">=4.9.3"
 
 # optional dependencies


### PR DESCRIPTION
uv pip fails to install if a newer version of requests library is in requirements.txt. Please add this change.