### PR TITLE
Fix/issue 93 incorrect tag order

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -284,7 +284,7 @@ Currently, inscriptis supports the following postprocessors:
 
       inscript --annotation-rules ./wikipedia.json \
                   --postprocessor html \
-                  https://en.wikipedia.org/wiki/Chur.html
+                  https://en.wikipedia.org/wiki/Chur
 
    Annotation rules encoded in the ``wikipedia.json`` file:
 

--- a/README.rst
+++ b/README.rst
@@ -236,7 +236,7 @@ that are suitable for your particular application. Post processors can be
 specified with the ``-p`` or ``--postprocessor`` command line argument::
 
   $ inscript https://www.fhgr.ch \
-          -r ./annotation/examples/annotation-profile.json \
+          -r ./examples/annotation/annotation-profile.json \
           -p surface
 
 
@@ -265,10 +265,12 @@ Currently, inscriptis supports the following postprocessors:
 - xml: returns an additional annotated text version::
 
     <?xml version="1.0" encoding="UTF-8" ?>
+    <content>
     <heading>Chur</heading>
 
     <emphasis>Chur</emphasis> is the capital and largest town of the Swiss
     canton of the Grisons and lies in the Grisonian Rhine Valley.
+    </content>
 
 - html: creates an HTML file which contains the converted text and highlights all annotations as outlined below:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "inscriptis"
-version = "2.5.3"
+version = "2.6.0"
 authors = ["Albert Weichselbraun <albert.weichselbraun@fhgr.ch>", "Fabian Odoni <fabian.odoni@fhgr.ch>"]
 description = "inscriptis - HTML to text converter."
 keywords = ["HTML", "converter", "text"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,11 @@ requests = ">=2.32.2"
 lxml = ">=4.9.3"
 
 # optional dependencies
-fastapi = { version = "^0.109.1", optional = true }
-uvicorn = { version = "^0.27.1", optional = true }
+fastapi = { version = "^0.115.11", optional = true }
+uvicorn = { version = "^0.34.0", optional = true }
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.3.5"
 
 
 [build-system]

--- a/src/inscriptis/annotation/__init__.py
+++ b/src/inscriptis/annotation/__init__.py
@@ -1,6 +1,5 @@
 """The model used for saving annotations."""
 
-from functools import total_ordering
 from typing import List
 from typing import NamedTuple
 

--- a/src/inscriptis/annotation/__init__.py
+++ b/src/inscriptis/annotation/__init__.py
@@ -1,5 +1,6 @@
 """The model used for saving annotations."""
 
+from functools import total_ordering
 from typing import List
 from typing import NamedTuple
 

--- a/src/inscriptis/annotation/output/__init__.py
+++ b/src/inscriptis/annotation/output/__init__.py
@@ -10,9 +10,9 @@ by overwrite the class's :meth:`AnnotationProcessor.__call__` method.
     2. The overwritten :meth:`__call__` method may either extend the original
        dictionary which contains the extracted text and annotations (e.g.,
        :class:`~inscriptis.annotation.output.surface.SurfaceExtractor`) or
-       may replace it with an custom output (e.g.,
+       may replace it with a custom output (e.g.,
        :class:`~inscriptis.annotation.output.html.HtmlExtractor` and
-       :class:`~inscriptis.annotation.output.xml.XmlExtractor`.
+       :class:`~inscriptis.annotation.output.xml.XmlExtractor`).
 
 Currently, Inscriptis supports the following built-in AnnotationProcessors:
 
@@ -25,6 +25,7 @@ Currently, Inscriptis supports the following built-in AnnotationProcessors:
     of the extracted annotations.
 
 """
+
 from typing import Dict, Any
 
 

--- a/src/inscriptis/annotation/output/xml.py
+++ b/src/inscriptis/annotation/output/xml.py
@@ -1,8 +1,8 @@
 """XML Annotation processor."""
-from collections import defaultdict
-from typing import Dict, Any, Tuple
 
-from lxml import etree
+from collections import defaultdict
+from typing import Dict, Any
+
 from inscriptis.annotation.output import AnnotationProcessor
 
 
@@ -11,101 +11,20 @@ class XmlExtractor(AnnotationProcessor):
 
     verbatim = True
 
-    def traverse_element(self, root, text, start, end, annotations, idx) -> int:
-        while idx + 1 < len(annotations):
-            idx += 1
-            next_start, next_end, label = annotations[idx]["label"]
-            # recurse?
-            if next_start < end:
-                leaf = etree.Element(root, label)
-                cascaded_end = self.traverse_element(leaf, text, next_start, next_end, idx)
-            else:
-                root.tail += text[start: cascaded_end]
-
-
-
-    def __call__(self, annotated_text: Dict[str, Any], root_element='r') -> str:
-        text = annotated_text["text"]
-        annotations = sorted(annotated_text["label"])
-        root = etree.Element(root_element)
-        current_annotation_idx = 0
-        while current_annotation_idx < len(annotations):
-            current_annotation_idx = self.traverse_element(root, text, annotations, idx)
-
-
-        for start, end, label in sorted(annotated_text["label"]):
-            current_element = etree.SubElement(root, label)
-            current_element.text = text[start:end]
-
-        return etree.tostring(root, pretty_print=True, xml_declaration=True, encoding="UTF-8")
-
-    def call3(self, annotated_text: Dict[str, Any]) -> str:
-        tag_indices = defaultdict(list)
-
-        for start, end, label in sorted(annotated_text["label"]):
-            length = end - start
-            tag_indices[start].append((label, length))
-            tag_indices[end].append(("/" + label, length))
+    def __call__(self, annotated_text: Dict[str, Any], root_element="content"):
+        tag_dict = defaultdict(list)
+        for start, end, tag in reversed(annotated_text["label"]):
+            tag_dict[start].append(f"<{tag}>")
+            tag_dict[end].insert(0, f"</{tag}>")
 
         current_idx = 0
-        tagged_content = ['<?xml version="1.0" encoding="UTF-8" ?>\n']
         text = annotated_text["text"]
-        for index, tags in sorted(tag_indices.items()):
+        tagged_content = ['<?xml version="1.0" encoding="UTF-8" ?>\n', "<content>\n"]
+        for index, tags in sorted(tag_dict.items()):
             tagged_content.append(text[current_idx:index])
-
-            # Separate closing vs opening tags
-            closing_tags = [t for t in tags if t[0].startswith("/")]
-            opening_tags = [t for t in tags if not t[0].startswith("/")]
-
-            # Sort closing tags by ascending length (so outer closes last)
-            closing_tags.sort(key=lambda x: x[1])
-            for tag, _ in closing_tags:
-                tagged_content.append(f"<{tag}>")
-
-            # Sort opening tags by descending length (so outer opens first)
-            opening_tags.sort(key=lambda x: x[1], reverse=True)
-            for tag, _ in opening_tags:
-                tagged_content.append(f"<{tag}>")
-
             current_idx = index
+            tagged_content.extend(tags)
+
         tagged_content.append(text[current_idx:])
-
-        return "".join(tagged_content)
-
-    def call2(self, annotated_text: Dict[str, Any]) -> str:
-        """Provide an XML version of the given text and annotations.
-
-        Args:
-            annotated_text: a dictionary containing the plain text and the
-                            extracted annotations.
-
-        Returns:
-            A string with the XML-version of the content.
-        """
-        tag_indices = defaultdict(list)
-
-        for start, end, label in sorted(annotated_text["label"]):
-            tag_indices[start].append(label)
-            tag_indices[end].append("/" + label)
-
-        current_idx = 0
-        tagged_content = ['<?xml version="1.0" encoding="UTF-8" ?>\n']
-        text = annotated_text["text"]
-        for index, tags in sorted(tag_indices.items()):
-            tagged_content.append(text[current_idx:index])
-            # close tags
-            tagged_content.extend(
-                [
-                    "<" + tag + ">"
-                    for tag in sorted(tags, reverse=True)
-                    if tag.startswith("/")
-                ]
-            )
-            # open tags
-            tagged_content.extend(
-                ["<" + tag + ">" for tag in sorted(tags) if not tag.startswith("/")]
-            )
-            current_idx = index
-        tagged_content.append(text[current_idx:])
-
+        tagged_content.append("\n</content>")
         return "".join(tagged_content)

--- a/src/inscriptis/annotation/output/xml.py
+++ b/src/inscriptis/annotation/output/xml.py
@@ -20,9 +20,9 @@ class XmlExtractor(AnnotationProcessor):
         current_idx = 0
         text = annotated_text["text"]
         tagged_content = ['<?xml version="1.0" encoding="UTF-8" ?>\n', "<content>\n"]
-        for index, tags in sorted(tag_dict.items()):
-            tagged_content.append(text[current_idx:index])
-            current_idx = index
+        for idx, tags in sorted(tag_dict.items()):
+            tagged_content.append(text[current_idx:idx])
+            current_idx = idx
             tagged_content.extend(tags)
 
         tagged_content.append(text[current_idx:])

--- a/src/inscriptis/annotation/output/xml.py
+++ b/src/inscriptis/annotation/output/xml.py
@@ -1,7 +1,8 @@
 """XML Annotation processor."""
 from collections import defaultdict
-from typing import Dict, Any
+from typing import Dict, Any, Tuple
 
+from lxml import etree
 from inscriptis.annotation.output import AnnotationProcessor
 
 
@@ -10,7 +11,68 @@ class XmlExtractor(AnnotationProcessor):
 
     verbatim = True
 
-    def __call__(self, annotated_text: Dict[str, Any]) -> str:
+    def traverse_element(self, root, text, start, end, annotations, idx) -> int:
+        while idx + 1 < len(annotations):
+            idx += 1
+            next_start, next_end, label = annotations[idx]["label"]
+            # recurse?
+            if next_start < end:
+                leaf = etree.Element(root, label)
+                cascaded_end = self.traverse_element(leaf, text, next_start, next_end, idx)
+            else:
+                root.tail += text[start: cascaded_end]
+
+
+
+    def __call__(self, annotated_text: Dict[str, Any], root_element='r') -> str:
+        text = annotated_text["text"]
+        annotations = sorted(annotated_text["label"])
+        root = etree.Element(root_element)
+        current_annotation_idx = 0
+        while current_annotation_idx < len(annotations):
+            current_annotation_idx = self.traverse_element(root, text, annotations, idx)
+
+
+        for start, end, label in sorted(annotated_text["label"]):
+            current_element = etree.SubElement(root, label)
+            current_element.text = text[start:end]
+
+        return etree.tostring(root, pretty_print=True, xml_declaration=True, encoding="UTF-8")
+
+    def call3(self, annotated_text: Dict[str, Any]) -> str:
+        tag_indices = defaultdict(list)
+
+        for start, end, label in sorted(annotated_text["label"]):
+            length = end - start
+            tag_indices[start].append((label, length))
+            tag_indices[end].append(("/" + label, length))
+
+        current_idx = 0
+        tagged_content = ['<?xml version="1.0" encoding="UTF-8" ?>\n']
+        text = annotated_text["text"]
+        for index, tags in sorted(tag_indices.items()):
+            tagged_content.append(text[current_idx:index])
+
+            # Separate closing vs opening tags
+            closing_tags = [t for t in tags if t[0].startswith("/")]
+            opening_tags = [t for t in tags if not t[0].startswith("/")]
+
+            # Sort closing tags by ascending length (so outer closes last)
+            closing_tags.sort(key=lambda x: x[1])
+            for tag, _ in closing_tags:
+                tagged_content.append(f"<{tag}>")
+
+            # Sort opening tags by descending length (so outer opens first)
+            opening_tags.sort(key=lambda x: x[1], reverse=True)
+            for tag, _ in opening_tags:
+                tagged_content.append(f"<{tag}>")
+
+            current_idx = index
+        tagged_content.append(text[current_idx:])
+
+        return "".join(tagged_content)
+
+    def call2(self, annotated_text: Dict[str, Any]) -> str:
         """Provide an XML version of the given text and annotations.
 
         Args:

--- a/src/inscriptis/html_engine.py
+++ b/src/inscriptis/html_engine.py
@@ -51,7 +51,9 @@ class Inscriptis:
       text = parser.get_text()
     """
 
-    def __init__(self, html_tree: lxml.html.HtmlElement, config: ParserConfig = None):
+    def __init__(
+        self, html_tree: lxml.html.HtmlElement, config: ParserConfig = None
+    ) -> None:
         # use the default configuration, if no config object is provided
         config = config or ParserConfig()
 

--- a/tests/test_annotation_output_processor.py
+++ b/tests/test_annotation_output_processor.py
@@ -48,11 +48,11 @@ def test_xml_annotator():
 
     # and we have additional information on surface forms :)
     assert result == (
-        '<?xml version="1.0" encoding="UTF-8" ?>\n'
+        '<?xml version="1.0" encoding="UTF-8" ?>\n<content>\n'
         "<h1><heading>Chur</heading></h1>\n\n<emphasis>"
         "Chur</emphasis> is the capital and largest town "
         "of the Swiss canton of the Grisons and lies in "
-        "the Grisonian Rhine Valley."
+        "the Grisonian Rhine Valley.\n</content>"
     )
 
 
@@ -81,6 +81,6 @@ def test_trailing_tag_annotation():
     result = processor({"text": "Ehre sei Gott!", "label": [[9, 14, "emphasis"]]})
 
     assert result == (
-        '<?xml version="1.0" encoding="UTF-8" ?>\n'
-        "Ehre sei <emphasis>Gott!</emphasis>"
+        '<?xml version="1.0" encoding="UTF-8" ?>\n<content>\n'
+        "Ehre sei <emphasis>Gott!</emphasis>\n</content>"
     )

--- a/tests/test_annotation_output_processor.py
+++ b/tests/test_annotation_output_processor.py
@@ -15,7 +15,7 @@ EXAMPLE_OUTPUT = {
     "text": "Chur\n\nChur is the capital and largest town of "
     "the Swiss canton of the Grisons and lies in the "
     "Grisonian Rhine Valley.",
-    "label": [[0, 4, "heading"], [0, 4, "h1"], [6, 10, "emphasis"]],
+    "label": [[0, 4, "h1"], [0, 4, "heading"], [6, 10, "emphasis"]],
 }
 
 
@@ -36,8 +36,8 @@ def test_surface_annotator():
 
     # and we have additional information on surface forms :)
     assert result["surface"] == [
-        ("heading", "Chur"),
         ("h1", "Chur"),
+        ("heading", "Chur"),
         ("emphasis", "Chur"),
     ]
 
@@ -49,7 +49,7 @@ def test_xml_annotator():
     # and we have additional information on surface forms :)
     assert result == (
         '<?xml version="1.0" encoding="UTF-8" ?>\n<content>\n'
-        "<h1><heading>Chur</heading></h1>\n\n<emphasis>"
+        "<heading><h1>Chur</h1></heading>\n\n<emphasis>"
         "Chur</emphasis> is the capital and largest town "
         "of the Swiss canton of the Grisons and lies in "
         "the Grisonian Rhine Valley.\n</content>"
@@ -60,9 +60,9 @@ def test_html_annotator():
     processor = HtmlExtractor()
     result = processor(EXAMPLE_OUTPUT)
 
+
     assert result.startswith("<html><head><style>")
-    assert result.endswith(
-        "</style></head>"
+    assert result.split("</style>")[1] ==  ("</head>"
         '<body><pre><span class="heading-label">heading'
         '</span><span class="heading">'
         '<span class="h1-label">h1</span><span class="h1">'
@@ -72,8 +72,7 @@ def test_html_annotator():
         '<span class="emphasis">Chur</span> is the capital '
         "and largest town of the Swiss canton of the "
         "Grisons and lies in the Grisonian Rhine Valley."
-        "</pre></body></html>"
-    )
+        "</pre></body></html>")
 
 
 def test_trailing_tag_annotation():

--- a/tests/test_annotation_output_xml.py
+++ b/tests/test_annotation_output_xml.py
@@ -3,12 +3,10 @@
 """
 Test the annotation XmlExtractor.
 """
-from platform import processor
-from xml.etree.ElementTree import fromstring
+from lxml.html import fromstring
 
 from inscriptis import Inscriptis, ParserConfig
 from inscriptis.annotation.output.xml import XmlExtractor
-
 
 
 def test_tag_error_issue_93():
@@ -26,43 +24,52 @@ def test_tag_error_issue_93():
        </body>
     </html>"""
 
-    expected_output_issue_93 = ("""<?xml version="1.0" encoding="UTF-8" ?>\n"""
-                                "<outer><inner>  Item1 </inner><inner>Item2 </inner><inner>Item3 </inner>"
-                                "<inner>Item4</inner></outer>")
+    expected_output_issue_93 = (
+        """<?xml version="1.0" encoding="UTF-8" ?>\n<content>\n"""
+        "<outer><inner>  Item1 </inner><inner>Item2 </inner><inner>Item3 </inner>"
+        "<inner>Item4</inner></outer>\n</content>"
+    )
     rules = {"div#class=a": ["outer"], "span#class=b": ["inner"]}
 
-    inscriptis = Inscriptis(fromstring(html_issue_93), ParserConfig(annotation_rules=rules))
-    annotated_html = {'text': inscriptis.get_text(),
-                      'label': inscriptis.get_annotations()}
-    print(">>>", annotated_html)
-
+    inscriptis = Inscriptis(
+        fromstring(html_issue_93), ParserConfig(annotation_rules=rules)
+    )
+    annotated_html = {
+        "text": inscriptis.get_text(),
+        "label": inscriptis.get_annotations(),
+    }
     result = XmlExtractor()(annotated_html)
-    print(result)
     assert result == expected_output_issue_93
+
 
 def test_tag_folding_issue_93_extended():
     html_issue_93 = """<html>
        <body>
          <div class="a">
          Some Test to add :)
-            <span class="b">Item1</span>
+            <span class="b">Item<b>1</b></span>
             <span class="b">Item2</span>
-            <span class="b">Item3</span>
-            <span class="b">Item4</span>
+            <span class="b"><b>Item3</b></span>
+            <span class="b"><b>It</b>e<b>m4</b></span>
          </div>
        </body>
     </html>"""
 
-    expected_output_issue_93 = ("""<?xml version="1.0" encoding="UTF-8" ?>\n"""
-                                "<outer>  Some Test to add :) <inner>Item1 </inner><inner>Item2 </inner><inner>Item3 </inner>"
-                                "<inner>Item4</inner></outer>")
-    rules = {"div#class=a": ["outer"], "span#class=b": ["inner"]}
+    expected_output_issue_93 = (
+        """<?xml version="1.0" encoding="UTF-8" ?>\n"""
+        """<content>\n"""
+        """<outer>  Some Test to add :) <inner>Item <bold>1</bold></inner> <inner>Item2 </inner>"""
+        """<inner><bold>Item3</bold></inner> <inner><bold>It</bold> e <bold>m4</bold></inner></outer>\n"""
+        """</content>"""
+    )
+    rules = {"div#class=a": ["outer"], "span#class=b": ["inner"], "b": ["bold"]}
 
-    inscriptis = Inscriptis(fromstring(html_issue_93), ParserConfig(annotation_rules=rules))
-    annotated_html = {'text': inscriptis.get_text(),
-                      'label': inscriptis.get_annotations()}
-    print(">>>", annotated_html)
-
+    inscriptis = Inscriptis(
+        fromstring(html_issue_93), ParserConfig(annotation_rules=rules)
+    )
+    annotated_html = {
+        "text": inscriptis.get_text(),
+        "label": inscriptis.get_annotations(),
+    }
     result = XmlExtractor()(annotated_html)
-    print(result)
     assert result == expected_output_issue_93

--- a/tests/test_annotation_output_xml.py
+++ b/tests/test_annotation_output_xml.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+"""
+Test the annotation XmlExtractor.
+"""
+from platform import processor
+from xml.etree.ElementTree import fromstring
+
+from inscriptis import Inscriptis, ParserConfig
+from inscriptis.annotation.output.xml import XmlExtractor
+
+
+
+def test_tag_error_issue_93():
+    """
+    Test for the correct tag order in the XmlOutput as described in Issue #93.
+    """
+    html_issue_93 = """<html>
+       <body>
+         <div class="a">
+            <span class="b">Item1</span>
+            <span class="b">Item2</span>
+            <span class="b">Item3</span>
+            <span class="b">Item4</span>
+         </div>
+       </body>
+    </html>"""
+
+    expected_output_issue_93 = ("""<?xml version="1.0" encoding="UTF-8" ?>\n"""
+                                "<outer><inner>  Item1 </inner><inner>Item2 </inner><inner>Item3 </inner>"
+                                "<inner>Item4</inner></outer>")
+    rules = {"div#class=a": ["outer"], "span#class=b": ["inner"]}
+
+    inscriptis = Inscriptis(fromstring(html_issue_93), ParserConfig(annotation_rules=rules))
+    annotated_html = {'text': inscriptis.get_text(),
+                      'label': inscriptis.get_annotations()}
+    print(">>>", annotated_html)
+
+    result = XmlExtractor()(annotated_html)
+    print(result)
+    assert result == expected_output_issue_93
+
+def test_tag_folding_issue_93_extended():
+    html_issue_93 = """<html>
+       <body>
+         <div class="a">
+         Some Test to add :)
+            <span class="b">Item1</span>
+            <span class="b">Item2</span>
+            <span class="b">Item3</span>
+            <span class="b">Item4</span>
+         </div>
+       </body>
+    </html>"""
+
+    expected_output_issue_93 = ("""<?xml version="1.0" encoding="UTF-8" ?>\n"""
+                                "<outer>  Some Test to add :) <inner>Item1 </inner><inner>Item2 </inner><inner>Item3 </inner>"
+                                "<inner>Item4</inner></outer>")
+    rules = {"div#class=a": ["outer"], "span#class=b": ["inner"]}
+
+    inscriptis = Inscriptis(fromstring(html_issue_93), ParserConfig(annotation_rules=rules))
+    annotated_html = {'text': inscriptis.get_text(),
+                      'label': inscriptis.get_annotations()}
+    print(">>>", annotated_html)
+
+    result = XmlExtractor()(annotated_html)
+    print(result)
+    assert result == expected_output_issue_93


### PR DESCRIPTION
- Improved both the HTML and XML Annotation postprocessors.
- Fixed #94 (XML tags are now closed in the correct order).
- **Breaking change**
  - the XmlAnnotationProcessor now uses a mandatory root element to ensure that the create XML is valid.
  - *Impact:*
     1. The created XML will contain a `<content>` root element, which contains all annotations.  
     2. The name of the root element can be overwritten, if the optional `root_element` parameter is provided to the annotation processor call.
- Documentation fixes.
- Updated dependencies and added `pytest` as a build dependency.