### PR TITLE
fix: allow to use lxml < 6.1.0 so it works with libxml2 2.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 
 dependencies = [
   "requests>=2.32.3,<3.0.0",
-  "lxml>=5.4.0,<6.0.0",
+  "lxml>=5.4.0,<6.1.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
I've ran tests with libxml2 2.15 and python 3.12, 3.13 and 3.14.

I didn't try with libxml2 2.14.

Closes #102 

With this patch, one can force lxml to 6.0.2 in dependencies. 

```toml
[tool.poetry.dependencies]
inscriptis = "~=2.7.0"
lxml = ">=6.0.2"
```
