### PR TITLE
fix: removed unnecessary upper python version and bound on lxml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "2.7.1"
 description = "inscriptis - HTML to text converter."
 license = "Apache-2.0"
 readme = "README.rst"
-requires-python = ">=3.10,<3.15"
+requires-python = ">=3.10"
 
 authors = [
         { name = "Albert Weichselbraun", email = "albert.weichselbraun@fhgr.ch" },
@@ -30,7 +30,7 @@ classifiers = [
 
 dependencies = [
   "requests>=2.32.3,<3.0.0",
-  "lxml>=5.4.0,<6.1.0",
+  "lxml>=5.4.0,<6.2.0",
 ]
 
 [project.urls]
@@ -44,18 +44,18 @@ inscriptis-api = "inscriptis.service.web:start"
 
 [project.optional-dependencies]
 web-service = [
-  "fastapi>=0.115.11,<1.0.0",
-  "uvicorn>=0.34.0,<1.0.0"
+  "fastapi>=0.118.0,<1.0.0",
+  "uvicorn>=0.38.0,<1.0.0"
 ]
 
 [dependency-groups]
 dev = [
-    "pytest>=9.0.1",
-    "fastapi>=0.115.11,<1.0.0",
-    "ruff>=0.14.5",
-    "httpx>=0.28.1",
+    "pytest>=9.0.2",
+    "fastapi>=0.118.0,<1.0.0",
+    "ruff>=0.15.17",
+    "httpx2>=2.4.0",
     "uvicorn>=0.38.0",
-    "ty>=0.0.1a26",
+    "ty>=0.0.50",
     "pytest-cov>=7.0.0",
     "safety>=3.7.0",
     "tox>=4.23.0",


### PR DESCRIPTION
- Removed upper bound on the Python version (Fixes #112)
- Relaxed lxml upper version to <= 6.2.0 (Fixes #111)