### PR TITLE
Single-line table cell annotations ignore center/right align

### DIFF
--- a/src/inscriptis/model/table.py
+++ b/src/inscriptis/model/table.py
@@ -127,8 +127,10 @@ class TableCell(Canvas):
 
         # the easy case - the cell has only one line :)
         if len(self.blocks) == 1:
+            content_width = self.line_width[0]
+            result = horizontal_shift(self.annotations, content_width, self.width, self.align, idx)
             self.line_width[0] = self.width
-            return horizontal_shift(self.annotations, self.line_width[0], self.width, self.align, idx)
+            return result
 
         # the more challenging one - multiple cell lines
         line_break_pos = list(accumulate(self.line_width))

--- a/tests/test_table_cell_annotation_align.py
+++ b/tests/test_table_cell_annotation_align.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+"""Annotations in single-line table cells must follow horizontal alignment."""
+
+from copy import deepcopy
+
+from inscriptis import get_annotated_text
+from inscriptis.css_profiles import CSS_PROFILES
+from inscriptis.model.config import ParserConfig
+
+config = ParserConfig(css=deepcopy(CSS_PROFILES["strict"]), annotation_rules={"span": ["s"]})
+
+
+def test_single_line_center_align_annotation():
+    html = "<table><tr><td align='center'><span>x</span></td></tr><tr><td>wwwwww</td></tr></table>"
+    result = get_annotated_text(html, config)
+    assert result["text"] == "  x   \nwwwwww\n"
+    assert result["label"] == [(2, 3, "s")]
+    assert result["text"][2:3] == "x"
+
+
+def test_single_line_right_align_annotation():
+    html = "<table><tr><td align='right'><span>x</span></td></tr><tr><td>wwwwww</td></tr></table>"
+    result = get_annotated_text(html, config)
+    assert result["text"] == "     x\nwwwwww\n"
+    assert result["label"] == [(5, 6, "s")]
+    assert result["text"][5:6] == "x"
+
+
+def test_single_line_left_align_annotation():
+    html = "<table><tr><td align='left'><span>x</span></td></tr><tr><td>wwwwww</td></tr></table>"
+    result = get_annotated_text(html, config)
+    assert result["text"] == "x     \nwwwwww\n"
+    assert result["label"] == [(0, 1, "s")]
+    assert result["text"][0:1] == "x"


### PR DESCRIPTION
get_annotated_text hits WrongAnnotationSpan when single-line table cell center/right align skips horizontal_shift. This PR fixes the regression with a focused test covering the case.
