### PR TITLE
HtmlExtractor trailing newlines emit broken </pre></pre>

### DIFF
--- a/src/inscriptis/annotation/output/html.py
+++ b/src/inscriptis/annotation/output/html.py
@@ -37,7 +37,7 @@ class HtmlExtractor(AnnotationProcessor):
             tagged_content.append(text[current_idx:idx].replace("\n", "</pre>\n<pre>"))
             current_idx = idx
             tagged_content.extend(tags)
-        tagged_content.append(text[current_idx:].replace("\n", "</pre>\n</pre>"))
+        tagged_content.append(text[current_idx:].replace("\n", "</pre>\n<pre>"))
         return "".join(tagged_content) + "</pre></body></html>"
 
     @staticmethod

--- a/tests/test_annotation_output_processor.py
+++ b/tests/test_annotation_output_processor.py
@@ -83,3 +83,18 @@ def test_trailing_tag_annotation():
     assert result == (
         '<?xml version="1.0" encoding="UTF-8" ?>\n<content>\nEhre sei <emphasis>Gott!</emphasis>\n</content>'
     )
+
+
+def test_html_annotator_trailing_newlines():
+    """Trailing text after the last annotation must reopen <pre> per newline."""
+    processor = HtmlExtractor()
+    result = processor({"text": "Hi\nthere\nend", "label": [[0, 2, "greeting"]]})
+    body = result.split("</style>")[1]
+    assert "</pre>\n</pre>" not in body
+    assert body == (
+        "</head><body><pre>"
+        '<span class="greeting-label">greeting</span><span class="greeting">Hi</span>'
+        "</pre>\n"
+        "<pre>there</pre>\n"
+        "<pre>end</pre></body></html>"
+    )


### PR DESCRIPTION
HtmlExtractor hits MalformedHtml when trailing newline replace uses /pre /pre instead of /pre pre. This PR fixes the regression with a focused test covering the case.
