### PR TITLE
chg: use ubuntu 26.04 for building packages.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
chg: use ubuntu 26.04 for building packages.